### PR TITLE
Update pom with current A4C stable version 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>alien4cloud</groupId>
     <artifactId>alien4cloud-parent</artifactId>
-    <version>1.1.0-SM8-SNAPSHOT</version>
+    <version>1.1.0</version>
   </parent>
   <artifactId>alien4cloud-plugin-sample</artifactId>
   <name>Alien 4 Cloud Plugin sample</name>


### PR DESCRIPTION
Current pom alien parent version (1.1.0-SM8-SNAPSHOT) is unresolvable in the maven repo. Master branch could be updated to use the stable 1.1.0 release.